### PR TITLE
Fix the GitHub actions set-env nuance across steps

### DIFF
--- a/.github/workflows/publish-artefact.yaml
+++ b/.github/workflows/publish-artefact.yaml
@@ -15,9 +15,12 @@ jobs:
     - name: git checkout
       uses: actions/checkout@v2
 
-    - name: Set useful variables
+    - name: Set chart name
       run: |
         echo '::set-env name=CHART_NAME::'$(echo ${GITHUB_REF##*/} | awk -F '-' '{print $1}')
+
+    - name: Set useful variables
+      run: |
         echo '::set-env name=CHART_PATH::stable/'$CHART_NAME
         echo '::set-env name=ACTOR_LOWERCASE::'$(echo $GITHUB_ACTOR | tr '[:upper:]' '[:lower:]')
         echo '::set-env name=SHORT_SHA::'$(echo $GITHUB_SHA|head -c 7)


### PR DESCRIPTION
### Changelog:
- GitHub actions has a set-env nuance where you can't use an environment variable you have just set in a step, to set another environment variable, in the same step. Moved setting the chart name outside of the bulk of the main set.
