### PR TITLE
Adding conditions to enabling the pprof server

### DIFF
--- a/stable/autonity-network/README.md
+++ b/stable/autonity-network/README.md
@@ -56,6 +56,9 @@ The following table lists some of the configurable parameters of the Autonity ch
 |-----------------------------------|-----------------------------------------------|---------------------------------------|
 | `debug_enabled`                   | Prepends log messages with call-site location | `false`                               |
 | `logging_verbosity`               | Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail | `3`         |
+| `pprof.enabled`                   | HTTP server for visualization and analysis of profiling data | `false`                |
+| `pprof.address`                   | The address the pprof server will listen on   | `127.0.0.1`                           |
+| `pprof.port`                      | The port the pprof server will start on       | `6060`                                |
 
 - You can change number of validators or observers using the `--set` options:
 
@@ -163,5 +166,3 @@ helm status autonity-network --namespace autonity-network
 helm delete autonity-network --namespace autonity-network
 kubectl delete namespace autonity-network
 ```
-
-

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -78,8 +78,6 @@ spec:
           - "--wsorigins"
           - "*"
           - "--metrics"
-          - "--pprof"
-          - "--pprofaddr"
           - "0.0.0.0"
           - "--networkid"
           - "{{ $networkid }}"
@@ -88,10 +86,17 @@ spec:
 {{ end }}
           - "--verbosity"
           - "{{ $loggingVerbosity }}"
-          - "--nousb"
+{{ if eq $pprofEnabled true }}
+          - "--pprof"
+          - "--pprof.addr"
+          - "{{ $pprofAddress }}"
+          - "--pprof.port"
+          - "{{ $pprofPort }}"
+{{ end }}
 {{ if $ethstatsEnabled }}
           - "--ethstats"
           - "observer-{{ $i }}:$(ETHSTATS_SECRET)@ethstats.{{ $namespace }}"
+          - "--nousb"
         env:
         - name: ETHSTATS_SECRET
           valueFrom:

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -92,10 +92,10 @@ spec:
           - "--pprof.port"
           - "{{ $pprofPort }}"
 {{ end }}
+          - "--nousb"
 {{ if $ethstatsEnabled }}
           - "--ethstats"
           - "observer-{{ $i }}:$(ETHSTATS_SECRET)@ethstats.{{ $namespace }}"
-          - "--nousb"
         env:
         - name: ETHSTATS_SECRET
           valueFrom:

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -5,14 +5,13 @@
 {{- $releasename := .Release.Name -}}
 {{- $debugEnabled := .Values.debug_enabled -}}
 {{- $loggingVerbosity := .Values.logging_verbosity -}}
-
+{{- $pprofEnabled := .Values.pprof.enabled -}}
+{{- $pprofAddress := .Values.pprof.address -}}
+{{- $pprofPort := .Values.pprof.port -}}
 {{- $networkid :=  .Values.networkid -}}
-
 {{- $ethstatsEnabled :=  .Values.global.ethstats.enabled -}}
 {{- $rpcHttpBasicAuthEnabled :=  .Values.rpc_http_basic_auth_enabled -}}
 {{- $rpcHttpsEnabled :=  .Values.rpc_https_enabled -}}
-
-
 {{- $awsPersistentStorageEnabled :=  .Values.aws_persistent_storage_enabled -}}
 {{- $gcpPersistentStorageEnabled :=  .Values.gcp_persistent_storage_enabled -}}
 

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -77,7 +77,6 @@ spec:
           - "--wsorigins"
           - "*"
           - "--metrics"
-          - "0.0.0.0"
           - "--networkid"
           - "{{ $networkid }}"
 {{ if eq $debugEnabled true }}

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -134,10 +134,10 @@ spec:
           - "--pprof.port"
           - "{{ $pprofPort }}"
 {{ end }}
+          - "--nousb"
 {{ if $ethstatsEnabled }}
           - "--ethstats"
           - "validator-{{ $i }}:$(ETHSTATS_SECRET)@ethstats.{{ $namespace }}"
-          - "--nousb"
         env:
         - name: ETHSTATS_SECRET
           valueFrom:

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -116,9 +116,6 @@ spec:
           - "--wsorigins"
           - "*"
           - "--metrics"
-          - "--pprof"
-          - "--pprofaddr"
-          - "0.0.0.0"
           - "--networkid"
           - "{{ $networkid }}"
           - "--mine"
@@ -130,6 +127,13 @@ spec:
           - "--verbosity"
           - "{{ $loggingVerbosity }}"
           - "--nousb"
+{{ if .Values.pprof }}
+          - "--pprof"
+          - "--pprof.addr"
+          - "{{ .Values.pprof.address }}"
+          - "--pprof.port"
+          - "{{ .Values.pprof.port"
+{{ end }}
 {{ if $ethstatsEnabled }}
           - "--ethstats"
           - "validator-{{ $i }}:$(ETHSTATS_SECRET)@ethstats.{{ $namespace }}"

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -127,7 +127,6 @@ spec:
 {{ end }}
           - "--verbosity"
           - "{{ $loggingVerbosity }}"
-          - "--nousb"
 {{ if eq $pprofEnabled true }}
           - "--pprof"
           - "--pprof.addr"
@@ -138,6 +137,7 @@ spec:
 {{ if $ethstatsEnabled }}
           - "--ethstats"
           - "validator-{{ $i }}:$(ETHSTATS_SECRET)@ethstats.{{ $namespace }}"
+          - "--nousb"
         env:
         - name: ETHSTATS_SECRET
           valueFrom:

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -8,9 +8,10 @@
 {{- $releasename := .Release.Name -}}
 {{- $debugEnabled := .Values.debug_enabled -}}
 {{- $loggingVerbosity := .Values.logging_verbosity -}}
-
+{{- $pprofEnabled := .Values.pprof.enabled -}}
+{{- $pprofAddress := .Values.pprof.address -}}
+{{- $pprofPort := .Values.pprof.port -}}
 {{- $networkid :=  .Values.networkid -}}
-
 {{- $ethstatsEnabled := .Values.global.ethstats.enabled -}}
 {{- $rpcHttpBasicAuthEnabled := .Values.rpc_http_basic_auth_enabled -}}
 {{- $rpcHttpsEnabled := .Values.rpc_https_enabled -}}
@@ -127,12 +128,12 @@ spec:
           - "--verbosity"
           - "{{ $loggingVerbosity }}"
           - "--nousb"
-{{ if .Values.pprof }}
+{{ if eq $pprofEnabled true }}
           - "--pprof"
           - "--pprof.addr"
-          - "{{ .Values.pprof.address }}"
+          - "{{ $pprofAddress }}"
           - "--pprof.port"
-          - "{{ .Values.pprof.port"
+          - "{{ $pprofPort }}"
 {{ end }}
 {{ if $ethstatsEnabled }}
           - "--ethstats"

--- a/stable/autonity-network/values.yaml
+++ b/stable/autonity-network/values.yaml
@@ -66,6 +66,8 @@ logging_verbosity: 3
 
 # pprof is for enabling the pprof HTTP server for visualization and analysis of profiling data
 pprof:
+  # enabled is setting the pprof server as enabled
+  enabled: true
   # address the pprof server address to listen on
   address: 127.0.0.1
   # port the pprof server port to start on

--- a/stable/autonity-network/values.yaml
+++ b/stable/autonity-network/values.yaml
@@ -64,6 +64,13 @@ global:
 debug_enabled: false
 logging_verbosity: 3
 
+# pprof is for enabling the pprof HTTP server for visualization and analysis of profiling data
+pprof:
+  # address the pprof server address to listen on
+  address: 127.0.0.1
+  # port the pprof server port to start on
+  port: 6060
+
 # Create an account for https://cloud2.influxdata.com
 # Uncomment and fill vars below to receive your metrics
 #


### PR DESCRIPTION
### Changelog
Resolves #53 

### Description
The `pprof` HTTP server can be connected to when its defined as `enabled` in the `values.yaml` and using `kubectl` to port foward first.

The port forward:
```
kubectl port-forward --namespace autonity-network svc/validator-0 6060:6060
```

Interacting with the pprof HTTP server:
```
➜  ~ go tool pprof http://localhost:6060/debug/pprof/heap
Fetching profile over HTTP from http://localhost:6060/debug/pprof/heap
Saved profile in /home/tudor/pprof/pprof.autonity.alloc_objects.alloc_space.inuse_objects.inuse_space.002.pb.gz
File: autonity
Type: inuse_space
Time: Oct 3, 2020 at 1:14pm (UTC)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 129.53MB, 98.36% of 131.69MB total
Dropped 17 nodes (cum <= 0.66MB)
Showing top 10 nodes out of 24
      flat  flat%   sum%        cum   cum%
     128MB 97.20% 97.20%      128MB 97.20%  github.com/syndtr/goleveldb/leveldb/memdb.New
    1.53MB  1.16% 98.36%     1.53MB  1.16%  github.com/clearmatics/autonity/metrics.newExpDecaySampleHeap (inline)
         0     0% 98.36%   128.52MB 97.59%  github.com/clearmatics/autonity/cmd/utils.RegisterEthService.func2
         0     0% 98.36%   128.52MB 97.59%  github.com/clearmatics/autonity/cmd/utils.StartNode
         0     0% 98.36%   128.52MB 97.59%  github.com/clearmatics/autonity/core/rawdb.NewLevelDBDatabaseWithFreezer
         0     0% 98.36%   128.52MB 97.59%  github.com/clearmatics/autonity/eth.New
         0     0% 98.36%   128.52MB 97.59%  github.com/clearmatics/autonity/ethdb/leveldb.New
         0     0% 98.36%     1.02MB  0.77%  github.com/clearmatics/autonity/les.init
         0     0% 98.36%     1.53MB  1.16%  github.com/clearmatics/autonity/metrics.NewExpDecaySample
         0     0% 98.36%     1.02MB  0.77%  github.com/clearmatics/autonity/metrics.NewRegisteredTimer
```

### Submissions
* [x] Have you followed the guidelines in our [contributing document](CONTRIBUTING.md)?
* [x] Is the `branch` name the same as the Helm chart name that you will release?
* [x] Has your change only affected one Helm chart?
* [ ] Have you increased the version of the Helm chart `Chart.yaml`?
* [x] Have you updated the [changelog](CHANGELOG.md)?

Note: Increasing the version in the `Chart.yaml` as this will form part of a release