### PR TITLE
Release autonity-demo-1.2.2

### DIFF
--- a/stable/autonity-demo/CHANGELOG.md
+++ b/stable/autonity-demo/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autonity to 0.4.1
 
 ## [Unreleased]
+- Migrated to Helm 3
+- Up autonity-network to 1.8.1
+- Up prometheus to 11.12.1
+- Up grafana to 5.5.7
+
 ## [1.1.0] - 2020-04-07
 ### Changed
 - Update dashboard to include new metrics

--- a/stable/autonity-demo/CHANGELOG.md
+++ b/stable/autonity-demo/CHANGELOG.md
@@ -4,18 +4,21 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.2.1
+## [Unreleased]
+
+#' [1.2.2] - 2020-11-03
+- Migrated to Helm 3
+- Up autonity-network to 1.8.1
+- Up prometheus to 11.12.1
+- Up grafana to 5.5.7
+- Added default value for `autonity-network.pprof.address`: `0.0.0.0` to fix prometheus metrics
+
+## [1.2.1] - 2020-09-02
 - Removed legacy implementation of Ethstats
 - Set apiVersion for legacy Helm 2 support for transition period
 - Moved dependencies to the main Chart.yaml
 - Updated Documentation to reflect Helm 3 updates
 - Autonity to 0.4.1
-
-## [Unreleased]
-- Migrated to Helm 3
-- Up autonity-network to 1.8.1
-- Up prometheus to 11.12.1
-- Up grafana to 5.5.7
 
 ## [1.1.0] - 2020-04-07
 ### Changed

--- a/stable/autonity-demo/Chart.yaml
+++ b/stable/autonity-demo/Chart.yaml
@@ -1,6 +1,6 @@
 name: autonity-demo
 apiVersion: v1
-version: 1.2.1
+version: 1.3.0
 kubeVersion: ">=1.15.11-0"
 description: Umbrella chart for Demo deploy autonity-network and supporting tools
 keywords:
@@ -12,17 +12,17 @@ sources:
 maintainers:
 - name: eastata
   email: aleksandr.poliakov@clearmatics.com
-appVersion: v0.4.1
+appVersion: v0.6.0
 dependencies:
   - name: autonity-network
     repository: "https://charts-ose.clearmatics.com"
-    version: 1.7.1
+    version: 1.8.1
     condition: global.autonity_network.enabled
   - name: prometheus
     repository: "@stable"
-    version: 11.0.4
+    version: 11.12.1
     condition: global.prometheus.enabled
   - name: grafana
     repository: "@stable"
-    version: 5.0.11
+    version: 5.5.7
     condition: global.grafana.enabled

--- a/stable/autonity-demo/Chart.yaml
+++ b/stable/autonity-demo/Chart.yaml
@@ -1,6 +1,6 @@
 name: autonity-demo
 apiVersion: v1
-version: 1.3.0
+version: 1.2.2
 kubeVersion: ">=1.15.11-0"
 description: Umbrella chart for Demo deploy autonity-network and supporting tools
 keywords:

--- a/stable/autonity-demo/values.yaml
+++ b/stable/autonity-demo/values.yaml
@@ -11,10 +11,11 @@ global:
   telepresence:
     enabled: false
 
-
 autonity-network:
   chainid: 1489
   networkid: 444888
+  pprof:
+    address: "0.0.0.0"
   validators:
     num: 4
     serviceType: "ClusterIP"


### PR DESCRIPTION
### Changelog
- Migrated to Helm 3
- Up autonity-network to 1.8.1
- Up prometheus to 11.12.1
- Up grafana to 5.5.7
- Added default value for `autonity-network.pprof.address`: `0.0.0.0` to fix prometheus metrics

### Submissions
* [x] Have you followed the guidelines in our [contributing document](CONTRIBUTING.md)?
* [x] Is the `branch` name the same as the Helm chart name that you will release?
* [x] Has your change only affected one Helm chart?
* [x] Have you increased the version of the Helm chart `Chart.yaml`?
* [x] Have you updated the [changelog](CHANGELOG.md)?

Issue https://github.com/clearmatics/www-devops/issues/71
