### PR TITLE
Replaced GKE with KinD (Kubernetes in Docker) for Workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,16 +31,16 @@ jobs:
         echo 'Short SHA: '$SHORT_SHA
         echo 'GitHub Run ID: '$GITHUB_RUN_ID
 
-    - name: Setup gcloud environment
-      uses: google-github-actions/setup-gcloud@v0.2.0
+    - name: Install Kind & Create cluster
+      uses: engineerd/setup-kind@v0.5.0
       with:
-        version: '290.0.1'
-        project_id: ${{ secrets.GCP_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
-
-    - name: Configure the kubeconfig
-      run: gcloud container clusters get-credentials ${{ secrets.GCP_CLUSTER_NAME }} --zone ${{ secrets.GCP_PROJECT_ZONE }} --project ${{ secrets.GCP_PROJECT_ID }}
+        version: v0.11.1
+        name: local-cluster
+        wait: 60s
+        skipClusterCreation: false
+    
+    - name: Test Kind cluster creation
+      run: kind get clusters
 
     - name: Install helm
       uses: azure/setup-helm@v1
@@ -68,26 +68,3 @@ jobs:
 
     - name: Run the tests
       run: helm test $GITHUB_HEAD_REF-$SHORT_SHA --namespace $ACTOR_LOWERCASE-$GITHUB_RUN_ID
-
-    - name: Delete the chart
-      if: ${{ always() }}
-      run: |
-        if [ $(helm ls -A | grep "$GITHUB_HEAD_REF-$SHORT_SHA" | grep "$ACTOR_LOWERCASE-$GITHUB_RUN_ID" | wc -l) -ne 0 ]
-        then
-          helm delete $GITHUB_HEAD_REF-$SHORT_SHA --namespace $ACTOR_LOWERCASE-$GITHUB_RUN_ID;
-        else
-          echo "Error: release not found"
-          exit 1
-        fi
-
-    - name: Delete the namespace
-      if: ${{ always() }}
-      run: |
-        if [ $(kubectl get namespaces -A | grep "$ACTOR_LOWERCASE-$GITHUB_RUN_ID " | wc -l) -ne 0 ]
-        then
-          kubectl delete namespace $ACTOR_LOWERCASE-$GITHUB_RUN_ID;
-        else
-          echo "Namespace does not exist"
-          # Helm does not manage namespaces, so exit with error
-          exit 1
-        fi

--- a/.github/workflows/publish-artefact.yaml
+++ b/.github/workflows/publish-artefact.yaml
@@ -35,16 +35,16 @@ jobs:
         echo 'Short SHA: '$SHORT_SHA
         echo 'GitHub Run ID: '$GITHUB_RUN_ID
 
-    - name: Setup gcloud environment
-      uses: google-github-actions/setup-gcloud@v0.2.0
+    - name: Install Kind & Create cluster
+      uses: engineerd/setup-kind@v0.5.0
       with:
-        version: '290.0.1'
-        project_id: ${{ secrets.GCP_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
-
-    - name: Configure the kubeconfig
-      run: gcloud container clusters get-credentials ${{ secrets.GCP_CLUSTER_NAME }} --zone ${{ secrets.GCP_PROJECT_ZONE }} --project ${{ secrets.GCP_PROJECT_ID }}
+        version: v0.11.1
+        name: local-cluster
+        wait: 60s
+        skipClusterCreation: false
+    
+    - name: Test Kind cluster creation
+      run: kind get clusters
 
     - name: Install helm
       uses: azure/setup-helm@v1
@@ -97,26 +97,3 @@ jobs:
     - name: Publish the main index
       run: |
         aws s3 cp ./repo/index.yaml s3://${S3_BUCKET_NAME} --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type "text/plain"
-
-    - name: Delete the chart
-      if: ${{ always() }}
-      run: |
-        if [ $(helm ls -A | grep "$CHART_NAME-$SHORT_SHA" | grep "$ACTOR_LOWERCASE-$GITHUB_RUN_ID" | wc -l) -ne 0 ]
-        then
-          helm delete $CHART_NAME-$SHORT_SHA --namespace $ACTOR_LOWERCASE-$GITHUB_RUN_ID
-        else
-          echo "Error: release not found"
-          exit 1
-        fi
-
-    - name: Delete the namespace
-      if: ${{ always() }}
-      run: |
-        if [ $(kubectl get namespaces -A | grep "$ACTOR_LOWERCASE-$GITHUB_RUN_ID " | wc -l) -ne 0 ]
-        then
-          kubectl delete namespace $ACTOR_LOWERCASE-$GITHUB_RUN_ID;
-        else
-          echo "Namespace does not exist"
-          # Helm does not manage namespaces, so exit with error
-          exit 1
-        fi


### PR DESCRIPTION
Resolves #101 

### Changelog
Updated the workflows to use [Kind](https://kind.sigs.k8s.io/) for the Kubernetes cluster rather than Google Cloud. This has also simplified the workflows somewhat, as there's now no need to clean up the cluster after the tests have finished, as the container will just be deleted.

### Submissions
* [x] Have you followed the guidelines in our [contributing document](CONTRIBUTING.md)?
~~Is the `branch` name the same as the Helm chart name that you will release?~~
~~Has your change only affected one Helm chart?~~
~~Have you increased the version of the Helm chart `Chart.yaml`?~~
~~Have you updated the [changelog](CHANGELOG.md)?~~
